### PR TITLE
Cambiado uso de File.exists? (ya no existe mas) por `File.exist?`

### DIFF
--- a/lib/tadb/table.rb
+++ b/lib/tadb/table.rb
@@ -56,8 +56,8 @@ class TADB::Table
   end
 
   def file(mode, &block)
-    Dir.mkdir('./db') unless File.exists?('./db')
-    clear unless File.exists?(db_path)
+    Dir.mkdir('./db') unless File.exist?('./db')
+    clear unless File.exist?(db_path)
 
     File.open(db_path, mode) do |file|
       # The new File object is buffered mode (or non-sync mode), unless filename is a tty. See IO#flush, IO#fsync, IO#fdatasync, and IO#sync= about sync mode.

--- a/tadb.gemspec
+++ b/tadb.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb']
 
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.2'
-  spec.add_development_dependency 'bundler', '~> 2.2.15'
+  spec.add_development_dependency 'bundler', '~> 2.4.10'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.10'
+  spec.add_development_dependency 'rspec', '~> 3.12'
 end


### PR DESCRIPTION
`#File>exists?`, que estaba deprecado en ruby, se eliminó en la versión ..... En este PR estoy reemplazandolo por `#File>exist?`, que ya existía también en versiones anteriores de ruby.