### PR TITLE
Update workflow.yml

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,16 +1,22 @@
 name: TADB basic build
-on: [push,pull_request]
+on:
+  push:
+    branches:
+     - main
+  pull_request:
 jobs:
   rspec-test:
     name: RSpec
-    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        ruby-version: [2.7.2, 3.0.0]
+        os: [ubuntu-latest]
+        ruby-version: [2.7, 3.0, 3.1, 3.2]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
       # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
       # change this to (see https://github.com/ruby/setup-ruby#versioning):


### PR DESCRIPTION
Vi que el mismo workflow estaba corriendo dos veces ante un PR (una por `push` y otra por `pull_request`), y también actualicé `actions/checkout` por el warning de la versión de node deprecada.